### PR TITLE
Add stdin/stdout support with --std flag for editor integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ java -jar ktfmt-cli.jar --check
 java -jar ktfmt-cli.jar --check src/**/*.kt
 ```
 
+**Format from stdin** (for editor integrations):
+```bash
+echo "class Test{val x=1}" | java -jar ktfmt-cli.jar --std
+cat MyFile.kt | java -jar ktfmt-cli.jar --std --style=google
+```
+
 ### Command-Line Options
 
 ```
@@ -66,6 +72,7 @@ Arguments:
 Mode Options (required):
     --write                         Write formatting changes to files
     --check                         Check if files need formatting, exit 1 if so
+    --std                           Read from stdin and write to stdout
 
 Formatting Options:
     --style [meta]                  Formatting style: meta (default), google, or kotlinlang
@@ -129,6 +136,18 @@ java -jar ktfmt-cli.jar --write --style=meta --manage-trailing-commas=true
 
 # Google and kotlinlang styles enable trailing commas by default
 java -jar ktfmt-cli.jar --write --style=google
+```
+
+**Format from stdin (for editor integrations like Zed):**
+```bash
+# Basic stdin formatting
+echo "class Test{val x=1}" | java -jar ktfmt-cli.jar --std
+
+# With custom style
+cat MyFile.kt | java -jar ktfmt-cli.jar --std --style=google
+
+# With custom formatting options
+echo "fun test(){println(\"hello\")}" | java -jar ktfmt-cli.jar --std --max-width=80 --style=kotlinlang
 ```
 
 **Performance tuning:**

--- a/src/test/kotlin/io/github/ukarlsson/ktfmtcli/ModeTest.kt
+++ b/src/test/kotlin/io/github/ukarlsson/ktfmtcli/ModeTest.kt
@@ -27,6 +27,7 @@ class ModeTest :
             manageTrailingCommas = null,
             write = false,
             check = false,
+            std = false,
             debug = false,
             concurrency = 1,
             cacheLocation = null,
@@ -53,6 +54,7 @@ class ModeTest :
             manageTrailingCommas = null,
             write = true,
             check = true,
+            std = false,
             debug = false,
             concurrency = 1,
             cacheLocation = null,
@@ -79,11 +81,93 @@ class ModeTest :
             manageTrailingCommas = null,
             write = true,
             check = false,
+            std = false,
             debug = false,
             concurrency = 1,
             cacheLocation = null,
           )
         exitCode shouldBe 0
+      }
+
+      it("should accept std mode") {
+        val fs = Jimfs.newFileSystem()
+        val workingDir = fs.getPath("/project")
+        Files.createDirectories(workingDir)
+
+        val app = App(fileSystem = fs, workingDirectory = workingDir)
+
+        // Test std mode should not fail validation
+        val exitCode =
+          app.runFormatting(
+            globs = listOf("**/*"),
+            style = "meta",
+            maxWidth = 100,
+            blockIndent = null,
+            continuationIndent = null,
+            removeUnusedImports = true,
+            manageTrailingCommas = null,
+            write = false,
+            check = false,
+            std = true,
+            debug = false,
+            concurrency = 1,
+            cacheLocation = null,
+          )
+        exitCode shouldBe 0
+      }
+
+      it("should reject std with write mode") {
+        val fs = Jimfs.newFileSystem()
+        val workingDir = fs.getPath("/project")
+        Files.createDirectories(workingDir)
+
+        val app = App(fileSystem = fs, workingDirectory = workingDir)
+
+        // Test multiple modes including std should return 1
+        val exitCode =
+          app.runFormatting(
+            globs = listOf("**/*"),
+            style = "meta",
+            maxWidth = 100,
+            blockIndent = null,
+            continuationIndent = null,
+            removeUnusedImports = true,
+            manageTrailingCommas = null,
+            write = true,
+            check = false,
+            std = true,
+            debug = false,
+            concurrency = 1,
+            cacheLocation = null,
+          )
+        exitCode shouldBe 1
+      }
+
+      it("should reject std with check mode") {
+        val fs = Jimfs.newFileSystem()
+        val workingDir = fs.getPath("/project")
+        Files.createDirectories(workingDir)
+
+        val app = App(fileSystem = fs, workingDirectory = workingDir)
+
+        // Test multiple modes including std should return 1
+        val exitCode =
+          app.runFormatting(
+            globs = listOf("**/*"),
+            style = "meta",
+            maxWidth = 100,
+            blockIndent = null,
+            continuationIndent = null,
+            removeUnusedImports = true,
+            manageTrailingCommas = null,
+            write = false,
+            check = true,
+            std = true,
+            debug = false,
+            concurrency = 1,
+            cacheLocation = null,
+          )
+        exitCode shouldBe 1
       }
     }
 
@@ -183,6 +267,28 @@ class ModeTest :
       }
     }
 
+    describe("stdin mode processing") {
+      it("should handle stdin read error gracefully") {
+        val fs = Jimfs.newFileSystem()
+        val workingDir = fs.getPath("/project")
+        Files.createDirectories(workingDir)
+
+        val app = App(fileSystem = fs, workingDirectory = workingDir)
+        val formattingOptions =
+          com.facebook.ktfmt.format.FormattingOptions(
+            blockIndent = 2,
+            continuationIndent = 4,
+            manageTrailingCommas = false,
+          )
+
+        // In test environment, stdin is closed, so processStdin should return error code
+        val exitCode = app.processStdin(formattingOptions)
+
+        // Should return 1 for IO error when stdin is not available
+        exitCode shouldBe 1
+      }
+    }
+
     describe("integration scenarios with jimfs") {
       it("should respect ignore patterns during file collection and processing") {
         val fs = Jimfs.newFileSystem()
@@ -213,6 +319,7 @@ class ModeTest :
             manageTrailingCommas = null,
             write = false,
             check = true,
+            std = false,
             debug = false,
             concurrency = 1,
             cacheLocation = null,
@@ -246,6 +353,7 @@ class ModeTest :
             manageTrailingCommas = null,
             write = false,
             check = true,
+            std = false,
             debug = false,
             concurrency = 1,
             cacheLocation = null,


### PR DESCRIPTION
Some editors like Zed only support stdin/stdout for code formatting,
so it would be nice to support that as well besides file paths.

From the [Zed manual](https://zed.dev/docs/configuring-zed?highlight=formatter#formatter)
> Formatters operate by receiving file content via standard input, reformatting it and then outputting it to standard output and so normally don't know the filename of what they are formatting

This change adds a new --std flag that:
- Reads Kotlin code from stdin and writes formatted output to stdout
- Works with all existing formatting options (styles, indentation, etc.)
- Is mutually exclusive with --write and --check modes
- Prevents file/pattern arguments when used
